### PR TITLE
Revert "yoshino-common: sepolicy: Label new idle_state node for power…

### DIFF
--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -103,8 +103,6 @@
 
 /sys/devices/soc/780000.qcom,msm-core/uio/uio1/name             u:object_r:sysfs_uio:s0
 
-/sys/devices/virtual/graphics/fb([0-3])+/idle_state             u:object_r:sysfs_graphics:s0
-
 /sys/devices/virtual/input/input[0-9]+/als_Itime                u:object_r:sysfs_tof_rgbcir:s0
 /sys/devices/virtual/input/input[0-9]+/als_gain                 u:object_r:sysfs_tof_rgbcir:s0
 /sys/devices/virtual/input/input[0-9]+/als_power_state          u:object_r:sysfs_tof_rgbcir:s0

--- a/sepolicy/vendor/hal_power_default.te
+++ b/sepolicy/vendor/hal_power_default.te
@@ -12,7 +12,6 @@ r_dir_file(hal_power_default, debugfs_wlan)
 # To do powerhint on nodes defined in powerhint.json
 allow hal_power_default sysfs_devfreq:dir search;
 allow hal_power_default sysfs_devfreq:{ file lnk_file } rw_file_perms;
-allow hal_power_default sysfs_graphics:file r_file_perms;
 allow hal_power_default sysfs_kgsl:dir search;
 allow hal_power_default sysfs_kgsl:{ file lnk_file } rw_file_perms;
 allow hal_power_default sysfs_msm_subsys:dir search;


### PR DESCRIPTION
… hal"

This has now been added to the lineage sepolicy upstream.

This reverts commit 5a34e9b00855abd1cd0114426a3e8f70693f2885.